### PR TITLE
fix: update footer email to help@infantcarecompass.live

### DIFF
--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -94,7 +94,7 @@ const Footer = () => {
                     href="mailto:help@infantcarecompass.live"
                     className="text-gray-300 hover:text-white transition-colors"
                   >
-                    helpsupport@infantcarecompass.live
+                    help@infantcarecompass.live
                   </a>
                 </div>
               </li>


### PR DESCRIPTION
This pull request updates the contact email address in the footer:
Changes the email from helpsupport@infantcarecompass.live to help@infantcarecompass.live
Adds a mailto: link so it's clickable for users
Visually tested in the local development environment for proper rendering
<img width="1307" height="366" alt="image" src="https://github.com/user-attachments/assets/5f731551-2916-486d-abcd-0dc1b2ea6538" />
