### PR TITLE
fix: scroll position now resets on route change

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,6 +6,7 @@ import { Outlet,useLocation,useMatches } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
 
 import CustomCursor from './components/CustomCursor';
+import ScrollToTop from './components/ScrollToTop';
 
 
 function App() {
@@ -17,6 +18,8 @@ function App() {
     <div className="w-full">
       <CustomCursor />
       {!hideLayout && <Header />}
+
+      <ScrollToTop />
       
       <main className="mt-24">
         <Outlet />

--- a/client/src/components/ScrollToTop.jsx
+++ b/client/src/components/ScrollToTop.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;


### PR DESCRIPTION
## 📄 Description
Implemented a scroll-to-top behavior on route change.  
This enhances user experience by ensuring that each new page starts from the top, rather than retaining the scroll position of the previous page.

## ✅ Checklist
- [x] My code follows the project’s coding guidelines.
- [x] I have tested these changes locally.
- [x] I have added necessary documentation/comments (if applicable).
- [x] I have linked the related issue.

## 🔗 Related Issue
Closes #101 

## 🙏 Additional Notes
- Added a reusable `ScrollToTop` component.
- Imported and used it in `App.jsx` to ensure it runs globally on route change.

