### PR TITLE
Improve News UI: consistent card sizing, hover effects, and fallback …

### DIFF
--- a/client/src/pages/News.jsx
+++ b/client/src/pages/News.jsx
@@ -106,11 +106,11 @@ const News = () => {
 
     return (
       <div
-        className={`group relative bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-2 ${news.featured ? 'ring-2 ring-gradient-to-r from-indigo-500 to-purple-500' : ''
-          }`}
-        style={{
-          animationDelay: `${index * 0.1}s`,
-        }}
+          className={`group relative bg-white rounded-2xl overflow-hidden shadow-lg hover:shadow-2xl hover:ring-2 hover:ring-indigo-400 transition-all duration-500 transform hover:-translate-y-2 flex flex-col`}
+          style={{
+            height: '100%', // Ensure card takes full height
+            animationDelay: `${index * 0.1}s`,
+          }}
         onMouseEnter={() => setHoveredCard(news.id)}
         onMouseLeave={() => setHoveredCard(null)}
       >


### PR DESCRIPTION
## 📄 Description

This PR improves the News Card section by:

- Making the hover animation smoother and consistent across all cards.
- Fixing a slight misalignment issue where one card looked a bit off.
- Adding a nice glow effect when you hover over cards (including the featured one).
- Showing a fallback design with an icon if the image fails to load, instead of it breaking the layout.

## ✅ Checklist
- [X] My code follows the project’s coding guidelines.
- [X] I have tested these changes locally.
- [X] I have added necessary documentation/comments 
- [X] I have linked the related issue

## 🔗 Related Issue
Closes #21

## 📸 Screenshots & video 
BEFORE
2nd card is slightly off in height and only the featured cards get blue lines
<img width="1920" height="918" alt="InfantCareCompass - Google Chrome 7_26_2025 5_10_35 AM" src="https://github.com/user-attachments/assets/b653b334-7f2b-49ee-9ec9-7c48e2464f41" />

AFTER
<img width="1916" height="915" alt="Screenshot (81)" src="https://github.com/user-attachments/assets/700f6bf4-9d7c-4380-9426-adb1729bc054" />


## 🙏 Additional Notes
This is my first contribution to the project — I’ve tested everything locally and ensured a smooth experience. Open to any suggestions!