### PR TITLE
Fix: Removed password strength from login and made cursor global

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,7 +5,6 @@ import Footer from './components/Footer';
 import { Outlet,useLocation,useMatches } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
 
-import CustomCursor from './components/CustomCursor';
 import ScrollToTop from './components/ScrollToTop';
 
 
@@ -16,7 +15,6 @@ function App() {
   return (
 
     <div className="w-full">
-      <CustomCursor />
       {!hideLayout && <Header />}
 
       <ScrollToTop />

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -9,10 +9,12 @@ import { RouterProvider } from "react-router-dom"; // Correct import for RouterP
 import router from "./routes/routes.jsx"; // Import your routes
 import { Provider } from 'react-redux';
 import {store} from './store/store.jsx'
+import CustomCursor from "./components/CustomCursor.jsx";
 createRoot(document.getElementById("root")).render(
   
 <Provider store={store}>
 <RouterProvider router={router} /> {/* Provides the router configuration */} 
+<CustomCursor />
 </Provider>
  
 );

--- a/client/src/pages/SignIn.jsx
+++ b/client/src/pages/SignIn.jsx
@@ -286,7 +286,7 @@ export default function Signin() {
               onChange={handleChange}
               onFocus={() => setFocusedField('password')}
               onBlur={() => setFocusedField(null)}
-              showPasswordStrength={true}
+              showPasswordStrength={false}
             />
 
             <div className="space-y-4">


### PR DESCRIPTION
<!-- PR Template -->

## 📄 Description  
This PR resolves two UI issues:

1. ✅ **Removed the password strength meter from the Login page**  
   - It was unnecessary during login and potentially confusing for users.
   - This feature should only exist in registration or password reset flows.

2. ✅ **Made the custom cursor visible on all pages including `/signin` and `/registration`**  
   - Previously these pages did not show the custom cursor because they were not wrapped inside the layout.
   - The cursor component was moved to `main.jsx` for global visibility.

## ✅ Checklist  
- [x] My code follows the project’s coding guidelines.  
- [x] I have tested these changes locally.  
- [x] I have added necessary documentation/comments (if applicable).  
- [x] I have linked the related issue (if applicable).

## 🔗 Related Issue  
Closes #118  <!-- Password strength on login page -->  
Closes #94  <!-- Custom cursor not visible on signin/registration -->

## 🙏 Additional Notes  
- Note: Issue #94 was already assigned to someone else. However, it remained unresolved and was closely tied to the fix for cursor visibility, so it has been included here to maintain UI consistency.
- Please let me know if you'd prefer a separate PR for that.
