### PR TITLE
fix: reset scroll position on page navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,34 +1,34 @@
-import './App.css';
-import Header from './components/Header';
-import Footer from './components/Footer';
+import "./App.css";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
 
-import { Outlet,useLocation,useMatches } from "react-router-dom";
-import { Toaster } from "react-hot-toast";
+import { Outlet, useMatches } from "react-router-dom";
+// import { Toaster } from "react-hot-toast";
 
+import FloatingScrollToTop from "./components/ScrollToTop";
+// import CustomCursor from "./components/CustomCursor";
 
-import FloatingScrollToTop from './components/ScrollToTop';
-import CustomCursor from './components/CustomCursor';
-
-import ScrollToTop from './components/ScrollToTop';
-
+import ScrollToTop from "./components/ScrollToTop";
+import ScrollRestoration from "./components/ScrollRestoration";
 
 function App() {
   const matches = useMatches();
   const hideLayout = matches.some((match) => match.handle?.noLayout);
 
-  return (
 
+  return (
     <div className="w-full">
+      <ScrollRestoration />
       {!hideLayout && <Header />}
 
       <ScrollToTop />
-      
+
       <main className="mt-24">
         <Outlet />
       </main>
 
       {!hideLayout && <Footer />}
-       <FloatingScrollToTop />
+      <FloatingScrollToTop />
     </div>
   );
 }

--- a/client/src/components/ScrollRestoration.jsx
+++ b/client/src/components/ScrollRestoration.jsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollRestoration = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: "instant", 
+    });
+  }, [location.pathname]); 
+
+  return null; 
+};
+
+export default ScrollRestoration;


### PR DESCRIPTION
## 📄 Description
This PR fixes the issue where scroll position from the previous page was retained when navigating via header links. Now, every page loads from the top, ensuring a smoother and more intuitive navigation experience.


## ✅ Checklist
- [x] My code follows the project’s coding guidelines.
- [x] I have tested these changes locally.
- [x] I have added necessary documentation/comments (if applicable).
- [x] I have linked the related issue (if applicable).

## 🔗 Related Issue
Closes #154 

## 📸 Screenshots & video (if applicable)
https://github.com/user-attachments/assets/c2acf0cf-ff36-4054-9a98-eb92afad3409

